### PR TITLE
Add Amazon Seller account configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Amazon Seller Module
+
+This Odoo module provides a basic framework for managing multiple Amazon
+seller accounts. Each account stores the following credentials:
+
+- **App ID**
+- **Client Secret**
+- **Refresh Token**
+- **Seller ID**
+
+Accounts can be configured from the **Settings** menu under *Amazon Seller*.

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,0 +1,15 @@
+{
+    'name': 'Amazon Seller',
+    'version': '1.0',
+    'summary': 'Manage Amazon seller accounts',
+    'description': 'Stores multiple Amazon seller accounts and credentials.',
+    'category': 'Sales',
+    'author': 'Your Company',
+    'depends': ['base'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/amazon_seller_account_views.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,1 @@
+from . import amazon_seller_account

--- a/models/amazon_seller_account.py
+++ b/models/amazon_seller_account.py
@@ -1,0 +1,12 @@
+from odoo import models, fields
+
+
+class AmazonSellerAccount(models.Model):
+    _name = 'amazon.seller.account'
+    _description = 'Amazon Seller Account'
+
+    name = fields.Char(string='Account Name', required=True)
+    app_id = fields.Char(string='App ID', required=True)
+    client_secret = fields.Char(string='Client Secret', required=True)
+    refresh_token = fields.Char(string='Refresh Token', required=True)
+    seller_id = fields.Char(string='Seller ID', required=True)

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_amazon_seller_account,amazon.seller.account,model_amazon_seller_account,base.group_system,1,1,1,1
+

--- a/views/amazon_seller_account_views.xml
+++ b/views/amazon_seller_account_views.xml
@@ -1,0 +1,39 @@
+<odoo>
+    <record id="view_amazon_seller_account_form" model="ir.ui.view">
+        <field name="name">amazon.seller.account.form</field>
+        <field name="model">amazon.seller.account</field>
+        <field name="arch" type="xml">
+            <form string="Amazon Seller Account">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="app_id"/>
+                        <field name="client_secret"/>
+                        <field name="refresh_token"/>
+                        <field name="seller_id"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_amazon_seller_account_tree" model="ir.ui.view">
+        <field name="name">amazon.seller.account.tree</field>
+        <field name="model">amazon.seller.account</field>
+        <field name="arch" type="xml">
+            <tree string="Amazon Seller Accounts">
+                <field name="name"/>
+                <field name="seller_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_amazon_seller_account" model="ir.actions.act_window">
+        <field name="name">Amazon Seller Accounts</field>
+        <field name="res_model">amazon.seller.account</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_amazon_seller_root" name="Amazon Seller" parent="base.menu_administration" sequence="10"/>
+    <menuitem id="menu_amazon_seller_account" name="Accounts" parent="menu_amazon_seller_root" action="action_amazon_seller_account"/>
+</odoo>


### PR DESCRIPTION
## Summary
- add root `__init__` to load models
- implement manifest for the module
- create Amazon Seller account model
- add access rights and configuration menu
- document the module

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6860205ac4c8832b8b5f3ceb31b23df1