### PR TITLE
Add feedback for verified accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,5 @@ seller accounts. Each account stores the following credentials:
 - **Marketplace** - selectable region where the account operates
 
 The module attempts to install the `python-amazon-sp-api` package during installation.
-After configuring an account, use the *Verify Connection* button to confirm that the provided credentials work with Amazon's Selling Partner API.
+After configuring an account, use the *Verify Connection* button to test your credentials.
+You can also click *Verify & Save* to validate the connection and persist the record in one step.

--- a/models/amazon_seller_account.py
+++ b/models/amazon_seller_account.py
@@ -2,7 +2,7 @@ import subprocess
 import sys
 import logging
 
-from odoo import models, fields, api
+from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
 
 from .utils import amazon_utils
@@ -80,7 +80,6 @@ class AmazonSellerAccount(models.Model):
                             if part.get('marketplace').get('countryCode') == rec.marketplace:
                                 if part.get('participation').get('isParticipating'):
                                     logger.info(f'Connection successful for {rec.name} in {rec.marketplace} marketplace.')
-                                    # TODO Show success message to user
                                     found_match = True
                                     break
 
@@ -96,4 +95,25 @@ class AmazonSellerAccount(models.Model):
                         f'Error verifying connection for {rec.name} in {rec.marketplace} marketplace \n\n\n\n{e}'
                     )
 
-        return True
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': _('Success'),
+                'message': _('Connection verified successfully.'),
+                'type': 'success',
+                'sticky': False,
+            }
+        }
+
+    def verify_and_save(self):
+        """Verify connection and persist the record if the credentials succeed."""
+        self.ensure_one()
+        result = self.verify_connection()
+        vals = self._convert_to_write(self._cache)
+        if self._origin and self._origin.id:
+            self._origin.write(vals)
+        else:
+            self._origin = self.create(vals)
+        result['params']['message'] = _('Connection verified and saved.')
+        return result

--- a/views/amazon_seller_account_views.xml
+++ b/views/amazon_seller_account_views.xml
@@ -13,6 +13,7 @@
                         <field name="seller_id"/>
                         <field name="marketplace"/>
                         <button string="Verify Connection" type="object" name="verify_connection" class="oe_highlight"/>
+                        <button string="Verify &amp; Save" type="object" name="verify_and_save" class="oe_highlight"/>
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
## Summary
- show notifications after verifying seller account credentials
- allow verifying and saving in a single step
- document the Verify & Save feature

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861259e6e34832bad2fc76be30cd9b8