### PR TITLE
Add product creation with Amazon fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,12 @@ The module also includes an **FBA Inventory Ledger** accessible from the *FBA* m
 For reliable results the ledger request explicitly sets `dataStartTime` and `dataEndTime` in ISO 8601 format. It starts 30 days prior to the most recent stored entry and ends at the time of the request.
 
 Ledger entries mirror the columns returned in the detail report including transaction type, quantity and fulfillment center. Duplicate entries are avoided by enforcing uniqueness on the combination of account, date, FNSKU, event type, reference ID and fulfillment center.
+
+Another scheduled task converts ledger entries into standard Odoo stock moves. It creates two warehouses automatically:
+
+* **FBA Inbound** (`FBAIN`) – used as the source location for `Receipts` events.
+* **FBA Transfer** (`FBATR`) – used for `WhseTransfer` movements.
+
+Unprocessed ledger lines generate stock moves between these warehouses based on the event type. Created moves are linked back to the ledger entry so the job can safely run repeatedly without creating duplicates.
+
+The cron job also checks for a product matching each ledger line's MSKU. If none exists, a new storable product is created automatically using the FNSKU as the internal reference. The product stores the ASIN and MSKU so further ledger imports reuse the same item.

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -6,7 +6,7 @@
     'description': 'Stores multiple Amazon seller accounts and credentials.',
     'category': 'Sales',
     'author': 'Your Company',
-    'depends': ['base'],
+    'depends': ['base', 'stock'],
     'data': [
         'security/ir.model.access.csv',
         'views/amazon_seller_account_views.xml',

--- a/data/cron.xml
+++ b/data/cron.xml
@@ -7,5 +7,13 @@
         <field name="interval_number">30</field>
         <field name="interval_type">minutes</field>
     </record>
+    <record id="ir_cron_create_inventory_transactions" model="ir.cron">
+        <field name="name">Create Inventory Transactions</field>
+        <field name="model_id" ref="model_amazon_fba_inventory_ledger"/>
+        <field name="state">code</field>
+        <field name="code">model.cron_create_inventory_transactions()</field>
+        <field name="interval_number">60</field>
+        <field name="interval_type">minutes</field>
+    </record>
 </odoo>
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,4 @@
 from . import amazon_seller_account
 
 from . import amazon_fba_inventory_ledger
+from . import product

--- a/models/amazon_fba_inventory_ledger.py
+++ b/models/amazon_fba_inventory_ledger.py
@@ -28,6 +28,7 @@ class AmazonFbaInventoryLedger(models.Model):
     country = fields.Char(string='Country')
     reconciled_quantity = fields.Float(string='Reconciled Quantity')
     unreconciled_quantity = fields.Float(string='Unreconciled Quantity')
+    stock_move_id = fields.Many2one('stock.move', string='Stock Move', readonly=True)
 
     _sql_constraints = [
         (
@@ -140,4 +141,84 @@ class AmazonFbaInventoryLedger(models.Model):
             _logger.info('Created ledger entry for %s on %s', fnsku, ledger_date)
 
         _logger.info('Completed fetching ledger for account %s', account.name)
+
+    @api.model
+    def _ensure_fba_warehouses(self):
+        """Ensure FBA warehouses used for ledger transactions exist."""
+        Warehouse = self.env['stock.warehouse']
+        company = self.env.company
+
+        inbound = Warehouse.search([('code', '=', 'FBAIN'), ('company_id', '=', company.id)], limit=1)
+        if not inbound:
+            inbound = Warehouse.create({
+                'name': 'FBA Inbound',
+                'code': 'FBAIN',
+                'company_id': company.id,
+            })
+
+        transfer = Warehouse.search([('code', '=', 'FBATR'), ('company_id', '=', company.id)], limit=1)
+        if not transfer:
+            transfer = Warehouse.create({
+                'name': 'FBA Transfer',
+                'code': 'FBATR',
+                'company_id': company.id,
+            })
+
+        return inbound, transfer
+
+    @api.model
+    def cron_create_inventory_transactions(self):
+        """Create Odoo stock moves from unprocessed ledger entries."""
+        inbound_wh, transfer_wh = self._ensure_fba_warehouses()
+
+        unprocessed = self.search([('stock_move_id', '=', False)])
+        Product = self.env['product.product']
+        Template = self.env['product.template']
+
+        for entry in unprocessed:
+            product = Product.search([('amazon_msku', '=', entry.msku)], limit=1)
+            if not product:
+                product = Product.search([('default_code', '=', entry.fnsku)], limit=1)
+            if not product:
+                template = Template.create({
+                    'name': entry.title or entry.asin or entry.msku or entry.fnsku,
+                    'type': 'product',
+                })
+                product = template.product_variant_id
+                product.write({
+                    'default_code': entry.fnsku,
+                    'amazon_asin': entry.asin,
+                    'amazon_msku': entry.msku,
+                })
+
+            qty = abs(entry.quantity)
+            if qty <= 0:
+                continue
+
+            if entry.event_type == 'Receipts':
+                src_loc = inbound_wh.lot_stock_id.id
+                dest_loc = transfer_wh.lot_stock_id.id
+            elif entry.event_type == 'WhseTransfer':
+                if entry.quantity > 0:
+                    src_loc = inbound_wh.lot_stock_id.id
+                    dest_loc = transfer_wh.lot_stock_id.id
+                else:
+                    src_loc = transfer_wh.lot_stock_id.id
+                    dest_loc = inbound_wh.lot_stock_id.id
+            else:
+                continue
+
+            move = self.env['stock.move'].create({
+                'name': f'FBA {entry.event_type}',
+                'product_id': product.id,
+                'product_uom': product.uom_id.id,
+                'product_uom_qty': qty,
+                'location_id': src_loc,
+                'location_dest_id': dest_loc,
+            })
+            move._action_confirm()
+            move._action_done()
+            entry.stock_move_id = move.id
+
+        return True
 

--- a/models/product.py
+++ b/models/product.py
@@ -1,0 +1,10 @@
+from odoo import models, fields
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    amazon_asin = fields.Char(string='ASIN')
+    amazon_msku = fields.Char(string='MSKU')
+    _sql_constraints = [
+        ('amazon_msku_unique', 'unique(amazon_msku)', 'A product with this MSKU already exists.'),
+    ]

--- a/views/amazon_fba_inventory_views.xml
+++ b/views/amazon_fba_inventory_views.xml
@@ -11,6 +11,7 @@
                     <field name="quantity"/>
                     <field name="fulfillment_center"/>
                     <field name="account_id"/>
+                    <field name="stock_move_id"/>
                 </list>
             </field>
         </record>
@@ -37,6 +38,7 @@
                             <field name="country"/>
                             <field name="reconciled_quantity"/>
                             <field name="unreconciled_quantity"/>
+                            <field name="stock_move_id"/>
                         </group>
                     </sheet>
                 </form>


### PR DESCRIPTION
## Summary
- extend products with ASIN and MSKU info
- automatically create products when processing ledger lines
- document automatic product creation

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686efdef3c80832ba33a015e882ca2f0