### PR TITLE
Update FBA warehouse handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,7 @@ For reliable results the ledger request explicitly sets `dataStartTime` and `dat
 
 Ledger entries mirror the columns returned in the detail report including transaction type, quantity and fulfillment center. Duplicate entries are avoided by enforcing uniqueness on the combination of account, date, FNSKU, event type, reference ID and fulfillment center.
 
-Another scheduled task converts ledger entries into standard Odoo stock moves. It creates two warehouses automatically:
-
-* **FBA Inbound** (`FBAIN`) – used as the source location for `Receipts` events.
-* **FBA Transfer** (`FBATR`) – used for `WhseTransfer` movements.
-
-Unprocessed ledger lines generate stock moves between these warehouses based on the event type. Created moves are linked back to the ledger entry so the job can safely run repeatedly without creating duplicates.
+Another scheduled task converts ledger entries into standard Odoo stock moves. It creates a single **FBA** warehouse automatically. The warehouse's receipt location is used as the source for `Receipts` events while the internal stock location handles `WhseTransfer` movements. Unprocessed ledger lines generate stock moves between these locations based on the event type. Created moves are linked back to the ledger entry so the job can safely run repeatedly without creating duplicates.
 
 
 The cron job looks for a product with the same ASIN as each ledger line. If one doesn't exist, a new storable product is created automatically using the FNSKU as the internal reference. The product stores the ASIN so subsequent ledger imports reuse the same item.

--- a/models/amazon_fba_inventory_ledger.py
+++ b/models/amazon_fba_inventory_ledger.py
@@ -143,33 +143,25 @@ class AmazonFbaInventoryLedger(models.Model):
         _logger.info('Completed fetching ledger for account %s', account.name)
 
     @api.model
-    def _ensure_fba_warehouses(self):
-        """Ensure FBA warehouses used for ledger transactions exist."""
+    def _ensure_fba_warehouse(self):
+        """Ensure a single FBA warehouse exists and return it."""
         Warehouse = self.env['stock.warehouse']
         company = self.env.company
 
-        inbound = Warehouse.search([('code', '=', 'FBAIN'), ('company_id', '=', company.id)], limit=1)
-        if not inbound:
-            inbound = Warehouse.create({
-                'name': 'FBA Inbound',
-                'code': 'FBAIN',
+        warehouse = Warehouse.search([('code', '=', 'FBA'), ('company_id', '=', company.id)], limit=1)
+        if not warehouse:
+            warehouse = Warehouse.create({
+                'name': 'FBA',
+                'code': 'FBA',
                 'company_id': company.id,
             })
 
-        transfer = Warehouse.search([('code', '=', 'FBATR'), ('company_id', '=', company.id)], limit=1)
-        if not transfer:
-            transfer = Warehouse.create({
-                'name': 'FBA Transfer',
-                'code': 'FBATR',
-                'company_id': company.id,
-            })
-
-        return inbound, transfer
+        return warehouse
 
     @api.model
     def cron_create_inventory_transactions(self):
         """Create Odoo stock moves from unprocessed ledger entries."""
-        inbound_wh, transfer_wh = self._ensure_fba_warehouses()
+        warehouse = self._ensure_fba_warehouse()
 
         unprocessed = self.search([('stock_move_id', '=', False)])
         Product = self.env['product.product']
@@ -212,15 +204,15 @@ class AmazonFbaInventoryLedger(models.Model):
                 continue
 
             if entry.event_type == 'Receipts':
-                src_loc = inbound_wh.lot_stock_id.id
-                dest_loc = transfer_wh.lot_stock_id.id
+                src_loc = warehouse.wh_input_stock_loc_id.id
+                dest_loc = warehouse.lot_stock_id.id
             elif entry.event_type == 'WhseTransfer':
                 if entry.quantity > 0:
-                    src_loc = inbound_wh.lot_stock_id.id
-                    dest_loc = transfer_wh.lot_stock_id.id
+                    src_loc = warehouse.wh_input_stock_loc_id.id
+                    dest_loc = warehouse.lot_stock_id.id
                 else:
-                    src_loc = transfer_wh.lot_stock_id.id
-                    dest_loc = inbound_wh.lot_stock_id.id
+                    src_loc = warehouse.lot_stock_id.id
+                    dest_loc = warehouse.wh_input_stock_loc_id.id
             else:
                 continue
 


### PR DESCRIPTION
## Summary
- create one FBA warehouse instead of two
- use the warehouse's receipt and internal locations for FBA inventory moves
- document the new single warehouse approach in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f0ce64968832ba3643f53c29aba64