### PR TITLE
Set new products to track inventory by quantity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Ledger entries mirror the columns returned in the detail report including transa
 Another scheduled task converts ledger entries into standard Odoo stock moves. It creates a single **FBA** warehouse automatically. The warehouse's receipt location is used as the source for `Receipts` events while the internal stock location handles `WhseTransfer` movements. Unprocessed ledger lines generate stock moves between these locations based on the event type. Created moves are linked back to the ledger entry so the job can safely run repeatedly without creating duplicates.
 
 
-The cron job looks for a product with the same ASIN as each ledger line. If one doesn't exist, a new storable product is created automatically using the FNSKU as the internal reference. The product stores the ASIN so subsequent ledger imports reuse the same item.
+The cron job looks for a product with the same ASIN as each ledger line. If one doesn't exist, a new storable product is created automatically using the FNSKU as the internal reference. The product stores the ASIN so subsequent ledger imports reuse the same item. Newly created products are configured to track inventory by quantity only.

--- a/models/amazon_fba_inventory_ledger.py
+++ b/models/amazon_fba_inventory_ledger.py
@@ -211,6 +211,12 @@ class AmazonFbaInventoryLedger(models.Model):
                 if 'type' in Template._fields:
                     vals['type'] = product_type
 
+                # Ensure new products track inventory only by quantity.
+                # The `tracking` field controls lot/serial number tracking on
+                # product templates. Setting it to "none" keeps standard
+                # quantity-based stock management.
+                vals['tracking'] = 'none'
+
                 template = Template.create(vals)
 
                 product = template.product_variant_id


### PR DESCRIPTION
## Summary
- ensure automatic product creation sets `tracking` to `none` so stock is tracked by quantity
- document the quantity tracking behaviour for created products

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686fd1e79518832b905f4245b900f9f0